### PR TITLE
MAINT: add code to make squart and arndt supp fig

### DIFF
--- a/nbks/make_supp_quantiles_toe.ipynb
+++ b/nbks/make_supp_quantiles_toe.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,23 +42,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "paths = list(Path(\"../results/micro/toe/fg-GSN-toe/\").glob(\"*.tsv\"))\n",
     "fig = pq.get_quantile_fig(paths, \"chisq_pval\", alpha=0.8)\n",
     "# fig.show()\n",
-    "fig.write_image(FIG_DIR / \"quantiles-toe.pdf\")"
+    "# fig.write_image(FIG_DIR / \"quantiles-toe.pdf\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Squartini and Arndt chi squared test "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "paths = list(Path(\"../results/micro/chi2/\").glob(\"*.tsv\"))\n",
+    "fig = pq.get_quantile_fig(paths, \"chisq_pval\", alpha=0.8)\n",
+    "# fig.show()\n",
+    "# fig.write_image(FIG_DIR / \"quantiles-chi2.pdf\")"
    ]
   }
  ],
  "metadata": {
-  "interpreter": {
-   "hash": "cbba2c586c8ece813a5f7aa9f6ff7744ff5b0d63355ab49e33feef8cb8cb0591"
-  },
   "kernelspec": {
-   "display_name": "Python 3.10.0 ('c310dev')",
+   "display_name": "mdeq_analysis_env",
    "language": "python",
    "name": "python3"
   },
@@ -72,7 +88,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.18"
   },
   "orig_nbformat": 4
  },


### PR DESCRIPTION
add a cell to generate supplementary figure showing the application of Squartini and Arndt's chi^2 test to the synthetic data set